### PR TITLE
Add absolute_import to ensure python2.x compatibility

### DIFF
--- a/react/utils/pipeline.py
+++ b/react/utils/pipeline.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
+
 from pipeline.compilers import CompilerBase
 from pipeline.exceptions import CompilerError
 from react.jsx import JSXTransformer, TransformError


### PR DESCRIPTION
Fix the import of django-pipeline by forcing absolute import to avoid self import on python 2.x
