### PR TITLE
Fix for PyExecJS >= 1.0.5

### DIFF
--- a/react/jsx.py
+++ b/react/jsx.py
@@ -18,6 +18,8 @@ import react.source
 
 class JSXTransformer(object):
 
+    JSX_TRANSFORMER_JS_EXPR = '(global.JSXTransformer || module.exports)'
+
     def __init__(self):
         path = react.source.path_for('JSXTransformer.js')
         with open(path, 'rU') as f:
@@ -37,7 +39,8 @@ class JSXTransformer(object):
         """
         opts = {'harmony': harmony, 'stripTypes': strip_types}
         try:
-            result = self.context.call('JSXTransformer.transform', jsx, opts)
+            result = self.context.call(
+                '%s.transform' % self.JSX_TRANSFORMER_JS_EXPR, jsx, opts)
         except execjs.ProgramError as e:
             raise TransformError(e.message[7:])
         js = result['code']

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,6 @@ setup(
         'js/react/JSXTransformer.js',
     ]},
     install_requires=[
-        'PyExecJS >= 1.0.4',
+        'PyExecJS >= 1.0.5',
     ]
 )


### PR DESCRIPTION
Test plan:

```
% EXECJS_RUNTIME=Node python ./react/test/__main__.py
% EXECJS_RUNTIME=PhantomJS python ./react/test/__main__.py
```

It fails with JavaScriptCore runtime but does so in an older version (probably
because of Browserify).
