### PR TITLE
switch e.message to str(e)

### DIFF
--- a/react/jsx.py
+++ b/react/jsx.py
@@ -42,7 +42,7 @@ class JSXTransformer(object):
             result = self.context.call(
                 '%s.transform' % self.JSX_TRANSFORMER_JS_EXPR, jsx, opts)
         except execjs.ProgramError as e:
-            raise TransformError(e.message[7:])
+            raise TransformError(str(e))
         js = result['code']
         return js
 

--- a/react/utils/pipeline.py
+++ b/react/utils/pipeline.py
@@ -34,4 +34,4 @@ class JSXCompiler(CompilerBase):
         try:
             return self.transformer.transform(infile, outfile)
         except TransformError as e:
-            raise CompilerError(e.message)
+            raise CompilerError(str(e))


### PR DESCRIPTION
ProgramError and TransformError do not have "message" attribute, causing AttributeError whenever JSX Transformation fails.
Switching `e.message` to `str(e)` fixes the problem.