### PR TITLE
Enable passing of  and  arguments in pipeline compiler

### DIFF
--- a/react/utils/pipeline.py
+++ b/react/utils/pipeline.py
@@ -33,14 +33,16 @@ class JSXCompiler(CompilerBase):
         if not outdated and not force:
             return
 
+        # pipeline < 1.6 will raise `AttributeError`
+        # pipeline >= 1.6 will raise `KeyError`
         try:
             harmony = settings.REACT_HARMONY
-        except KeyError:
+        except (KeyError, AttributeError):
             harmony = False
 
         try:
             strip_types = settings.REACT_STRIP_TYPES
-        except KeyError:
+        except (KeyError, AttributeError):
             strip_types = False
 
         try:

--- a/react/utils/pipeline.py
+++ b/react/utils/pipeline.py
@@ -16,6 +16,7 @@ from __future__ import absolute_import
 
 from pipeline.compilers import CompilerBase
 from pipeline.exceptions import CompilerError
+from pipeline.conf import settings
 from react.jsx import JSXTransformer, TransformError
 
 class JSXCompiler(CompilerBase):
@@ -31,7 +32,23 @@ class JSXCompiler(CompilerBase):
     def compile_file(self, infile, outfile, outdated=False, force=False):
         if not outdated and not force:
             return
+
         try:
-            return self.transformer.transform(infile, outfile)
+            harmony = settings.REACT_HARMONY
+        except KeyError:
+            harmony = False
+
+        try:
+            strip_types = settings.REACT_STRIP_TYPES
+        except KeyError:
+            strip_types = False
+
+        try:
+            return self.transformer.transform(
+                infile,
+                outfile,
+                harmony=harmony,
+                strip_types=strip_types,
+            )
         except TransformError as e:
             raise CompilerError(str(e))


### PR DESCRIPTION
### What was wrong?

The pipeline compiler did not have a hook to allow specifying the `harmony` or `strip_tags` flags into the call to the transformer.
### How was it fixed.

Pull the values off of the pipeline settings object if present, otherwise default to `False` for both arguments.

This _should_ work with any version of `pipeline>=1.3`
#### Cute animal picture

![1](https://cloud.githubusercontent.com/assets/824194/13970799/bc5629b4-f050-11e5-9231-e145af9ca0d8.jpg)
